### PR TITLE
fixed memoization of RankedModel::Ranker::Mapper#finder

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -215,7 +215,8 @@ module RankedModel
       end
 
       def finder(order = :asc)
-        @finder ||= begin
+        @finder ||= {}
+        @finder[order] ||= begin
           _finder = instance_class
           columns = [instance_class.arel_table[instance_class.primary_key], instance_class.arel_table[ranker.column]]
           if ranker.scope


### PR DESCRIPTION
it now caches a value for each passed sort order; without this multiple calls to finder can cause weird flipping issues where whole list gets reversed
